### PR TITLE
feat: orb without rigidbody

### DIFF
--- a/src/gameplay/spells/mod.rs
+++ b/src/gameplay/spells/mod.rs
@@ -220,7 +220,7 @@ fn attack(
 fn handle_timers(
     time: Res<Time>,
     mut cooldowns: Query<&mut Cooldown, With<Spell>>,
-    mut durations: Query<&mut SpellDuration, With<PlayerProjectile>>,
+    mut durations: Query<&mut SpellDuration, With<CastSpell>>,
     mut thorn_dmg_timer: Query<&mut DamageCooldown, With<Thorn>>,
     mut root_timer: Query<(Entity, &mut Root), With<Enemy>>,
     mut bleed_timer: Query<(Entity, &mut Bleed), With<Enemy>>,


### PR DESCRIPTION
Is this something we should do? Changes orbs to use only colliders without a rigidbody. Orbs have no effect on physics of other entities. In this case wo dont even need a Kinematic (effects other) rigidbody.