### PR TITLE
Player Stats and Item Modifiers

### DIFF
--- a/src/gameplay/abilities/summon.rs
+++ b/src/gameplay/abilities/summon.rs
@@ -2,7 +2,7 @@ use crate::gameplay::abilities::{
     Ability, AbilityAssets, AbilityCooldown, UseAbility, init_ability_assets, try_use_ability,
 };
 use crate::gameplay::character_controller::CharacterController;
-use crate::gameplay::enemy::{Enemy, EnemyDamageEvent, EnemyType};
+use crate::gameplay::enemy::{Enemy, EnemyType, damage::EnemyDamageEvent};
 use crate::gameplay::player::{Direction, Player};
 use crate::gameplay::simple_animation::{AnimationIndices, AnimationPlayback, AnimationTimer};
 use crate::gameplay::{Health, Speed};

--- a/src/gameplay/damage_numbers.rs
+++ b/src/gameplay/damage_numbers.rs
@@ -3,6 +3,7 @@ use bevy_asset_loader::prelude::*;
 use serde::{Deserialize, Serialize};
 
 use crate::{AssetStates, screens::Screen};
+use rand::Rng;
 
 #[derive(Copy, Clone, Reflect, Deserialize, Serialize, Debug)]
 pub enum DamageType {
@@ -75,8 +76,10 @@ fn spawn_damage_numbers_from_messages(
         };
 
         let font_size = if msg.crit { 24.0 } else { 12.0 };
+        let mut rng = rand::rng();
+        let mut base_pos = Vec3::new(msg.world_pos.x, msg.world_pos.y + 10.0, 20.0);
 
-        let base_pos = Vec3::new(msg.world_pos.x, msg.world_pos.y + 10.0, 20.0);
+        base_pos.x += rng.random_range(-5.0..5.0);
         let snapped = Vec3::new(base_pos.x.round(), base_pos.y.round(), base_pos.z);
 
         let parent = commands

--- a/src/gameplay/enemy/damage.rs
+++ b/src/gameplay/enemy/damage.rs
@@ -1,0 +1,82 @@
+use bevy::prelude::*;
+use rand::Rng;
+
+use crate::gameplay::{
+    Despawn, Health,
+    damage_numbers::{DamageMessage, DamageType},
+    enemy::Enemy,
+    items::stats::{DerivedStats, StatId, Stats},
+    simple_animation::HurtAnimationTimer,
+};
+
+pub(crate) fn plugin(app: &mut App) {
+    app.add_observer(enemy_take_dmg);
+}
+
+#[derive(Event, Reflect)]
+pub(crate) struct EnemyDamageEvent {
+    pub entity_hit: Entity,
+    pub dmg: f32,
+    pub damage_type: DamageType,
+}
+
+#[derive(Event, Reflect)]
+pub(crate) struct EnemyKnockbackEvent {
+    pub entity_hit: Entity,
+    pub strength: f32,
+    pub dir: Vec2,
+}
+
+#[derive(Event, Reflect)]
+pub(crate) struct EnemyDeathEvent(pub Transform);
+
+fn enemy_take_dmg(
+    trigger: On<EnemyDamageEvent>,
+    stats_q: Single<&DerivedStats>,
+    mut damage_writer: MessageWriter<DamageMessage>,
+    mut enemy_q: Query<(&mut Health, &Transform), (With<Enemy>, Without<Despawn>)>,
+    mut commands: Commands,
+) {
+    let enemy_entity = trigger.entity_hit;
+    let stats = stats_q.0;
+
+    let (dmg, crit) = damage_calculator(trigger.dmg, &stats);
+
+    commands
+        .entity(enemy_entity)
+        .insert(HurtAnimationTimer::default());
+
+    if let Ok((mut health, transform)) = enemy_q.get_mut(enemy_entity) {
+        health.0 -= dmg;
+
+        //TODO: DamageType only really used for effects
+        damage_writer.write(DamageMessage {
+            amount: dmg as i32,
+            world_pos: transform.translation.truncate(),
+            crit,
+            damage_type: trigger.damage_type,
+        });
+
+        if health.0 <= 0.0 {
+            commands.trigger(EnemyDeathEvent(*transform));
+            commands.entity(enemy_entity).insert(Despawn);
+        }
+    }
+}
+
+pub fn damage_calculator(base_damage: f32, stats: &Stats) -> (f32, bool) {
+    let is_crit = {
+        let mut rng = rand::rng();
+        rng.random_bool(stats.get(StatId::CritChance).into())
+    };
+
+    let crit_multiplier = if is_crit {
+        stats.get(StatId::CritDamage)
+    } else {
+        1.0
+    };
+
+    let dmg = stats.get(StatId::Attack) + base_damage * crit_multiplier;
+
+    (dmg, is_crit)
+}

--- a/src/gameplay/items/inventory.rs
+++ b/src/gameplay/items/inventory.rs
@@ -1,0 +1,51 @@
+use bevy::{ecs::system::SystemParam, prelude::*};
+use std::collections::HashMap;
+
+use crate::gameplay::player::Inventory;
+
+use super::items::{ItemId, ItemLevel};
+
+/// SysParam player inventory items relations
+#[derive(SystemParam)]
+pub struct PlayerInventory<'w, 's> {
+    inventory: Query<'w, 's, &'static Inventory>,
+    items: Query<'w, 's, (&'static ItemId, &'static ItemLevel)>,
+}
+
+impl<'w, 's> PlayerInventory<'w, 's> {
+    /// Get all items owned by the given entity (player)
+    pub fn get_items(&self, owner: Entity) -> impl Iterator<Item = (Entity, &ItemId, &ItemLevel)> {
+        self.inventory
+            .iter_descendants(owner)
+            .filter_map(|item_entity| {
+                self.items
+                    .get(item_entity)
+                    .ok()
+                    .map(|(id, level)| (item_entity, id, level))
+            })
+    }
+
+    /// Get a specific item by ID
+    pub fn get_item(&self, owner: Entity, item_id: &str) -> Option<(Entity, &ItemLevel)> {
+        self.get_items(owner)
+            .find(|(_, id, _)| id.0 == item_id)
+            .map(|(entity, _, level)| (entity, level))
+    }
+
+    /// Get the current level of an item
+    pub fn get_item_level(&self, owner: Entity, item_id: &str) -> Option<u32> {
+        self.get_item(owner, item_id).map(|(_, level)| level.0)
+    }
+
+    /// Build a HashMap of item IDs to their current levels for the given owner
+    pub fn build_level_map(&self, owner: Entity) -> HashMap<String, u32> {
+        self.get_items(owner)
+            .map(|(_, id, level)| (id.0.clone(), level.0))
+            .collect()
+    }
+
+    /// Check if the owner has a specific item
+    pub fn has_item(&self, owner: Entity, item_id: &str) -> bool {
+        self.get_item(owner, item_id).is_some()
+    }
+}

--- a/src/gameplay/items/items.rs
+++ b/src/gameplay/items/items.rs
@@ -1,0 +1,102 @@
+use bevy::prelude::*;
+
+use crate::gameplay::items::loader::{ItemRegistry, ModRule};
+use crate::gameplay::items::stats::{ItemModifiers, RecalculateStats, Stats};
+use crate::gameplay::player::InInventoryOf;
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub enum ItemCategory {
+    Weapon,
+    Passive,
+}
+
+/// Rarity is fixed per item. E.g. some are more rare than others.
+#[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum ItemRarity {
+    Common,
+    Uncommon,
+    Rare,
+    Epic,
+    Legendary,
+}
+
+impl ItemRarity {
+    pub fn color(&self) -> Color {
+        match self {
+            ItemRarity::Common => Color::srgb(0.7, 0.7, 0.7),
+            ItemRarity::Uncommon => Color::srgb(0.3, 1.0, 0.3),
+            ItemRarity::Rare => Color::srgb(0.3, 0.5, 1.0),
+            ItemRarity::Epic => Color::srgb(0.7, 0.3, 1.0),
+            ItemRarity::Legendary => Color::srgb(1.0, 0.6, 0.0),
+        }
+    }
+}
+#[derive(Component, Clone, Debug, Eq, PartialEq, Hash)]
+pub struct ItemId(pub String);
+
+#[derive(Component, Copy, Clone, Debug)]
+pub struct ItemLevel(pub u32);
+
+#[derive(EntityEvent)]
+pub struct UpgradeItem {
+    pub entity: Entity, // target item
+    pub amount: i32,
+}
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_observer(on_upgrade_item);
+
+    app.add_systems(Update, recompute_item_modifiers_from_registry);
+}
+
+fn on_upgrade_item(
+    ev: On<UpgradeItem>,
+    mut q: Query<(&mut ItemLevel, &InInventoryOf)>,
+    mut commands: Commands,
+) {
+    if let Ok((mut lvl, equipped_to)) = q.get_mut(ev.entity) {
+        lvl.0 = (lvl.0 as i32 + ev.amount).max(0) as u32;
+        // Explicitly trigger recalculation for the owner
+        info!(
+            "Item upgraded to level {}, triggering recalc for owner {:?}",
+            lvl.0, equipped_to.0
+        );
+        commands.trigger(RecalculateStats {
+            entity: equipped_to.0,
+        });
+    }
+}
+
+fn recompute_item_modifiers_from_registry(
+    reg: Res<ItemRegistry>,
+    mut q: Query<
+        (&ItemId, &ItemLevel, &mut ItemModifiers),
+        Or<(Changed<ItemId>, Changed<ItemLevel>, Added<ItemModifiers>)>,
+    >,
+) {
+    for (id, level, mut mods) in &mut q {
+        let Some(def) = reg.get(&id.0) else {
+            *mods = ItemModifiers::default();
+            continue;
+        };
+
+        // Reset to identity each recompute.
+        mods.add = Stats::zero();
+        mods.mul = Stats::one();
+
+        for entry in def.rules.iter().copied() {
+            let value = entry.rule.value_at(level.0);
+            match entry.rule {
+                ModRule::LinearAdd { .. } => {
+                    if value != 0.0 {
+                        *mods.add.get_mut(entry.stat) += value;
+                    }
+                }
+                ModRule::ExpMul { .. } => {
+                    if value != 1.0 {
+                        *mods.mul.get_mut(entry.stat) *= value;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/gameplay/items/loader.rs
+++ b/src/gameplay/items/loader.rs
@@ -1,0 +1,209 @@
+use std::collections::HashMap;
+
+use bevy::prelude::*;
+
+use crate::gameplay::items::{
+    items::{ItemCategory, ItemRarity},
+    stats::{StatId, Stats},
+};
+
+#[derive(Clone, Copy, Debug)]
+pub enum ModRule {
+    /// add = base + per_level * level
+    LinearAdd { base: f32, per_level: f32 },
+    /// mul = base * (per_level ^ level)  (1.0-based)
+    ExpMul { base: f32, per_level: f32 },
+}
+
+impl ModRule {
+    pub(crate) fn value_at(&self, level: u32) -> f32 {
+        let level = level as f32;
+        match *self {
+            ModRule::LinearAdd { base, per_level } => base + per_level * level,
+            ModRule::ExpMul { base, per_level } => base * per_level.powf(level),
+        }
+    }
+
+    pub(crate) fn delta_between(&self, from: u32, to: u32) -> f32 {
+        self.value_at(to) - self.value_at(from)
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RuleEntry {
+    pub stat: StatId,
+    pub rule: ModRule,
+}
+
+#[derive(Clone, Debug)]
+pub struct ItemSpec {
+    pub name: &'static str,
+    pub category: ItemCategory,
+    pub rarity: ItemRarity,
+    pub max_level: u32,
+    pub evolution: Option<String>,
+    pub evolution_requirement: Option<String>,
+    pub rules: Vec<RuleEntry>,
+}
+
+impl ItemSpec {
+    fn for_each_value<F>(&self, level: u32, mut f: F)
+    where
+        F: FnMut(StatId, f32),
+    {
+        for entry in &self.rules {
+            f(entry.stat, entry.rule.value_at(level));
+        }
+    }
+
+    fn for_each_delta<F>(&self, from: u32, to: u32, mut f: F)
+    where
+        F: FnMut(StatId, f32),
+    {
+        for entry in &self.rules {
+            f(entry.stat, entry.rule.delta_between(from, to));
+        }
+    }
+
+    pub fn new(name: &'static str, category: ItemCategory) -> Self {
+        Self {
+            name,
+            category,
+            rarity: ItemRarity::Common,
+            max_level: 8,
+            evolution: None,
+            evolution_requirement: None,
+            rules: Vec::new(),
+        }
+    }
+
+    pub fn with_rarity(mut self, rarity: ItemRarity) -> Self {
+        self.rarity = rarity;
+        self
+    }
+
+    pub fn with_max_level(mut self, max_level: u32) -> Self {
+        self.max_level = max_level;
+        self
+    }
+
+    pub fn with_evolution(
+        mut self,
+        evolves_into: impl Into<String>,
+        requires: impl Into<String>,
+    ) -> Self {
+        self.evolution = Some(evolves_into.into());
+        self.evolution_requirement = Some(requires.into());
+        self
+    }
+
+    pub fn with_rule(mut self, stat: StatId, rule: ModRule) -> Self {
+        self.rules.push(RuleEntry { stat, rule });
+        self
+    }
+
+    pub fn linear_add(self, stat: StatId, base: f32, per_level: f32) -> Self {
+        self.with_rule(stat, ModRule::LinearAdd { base, per_level })
+    }
+
+    pub fn exp_mul(self, stat: StatId, base: f32, per_level: f32) -> Self {
+        self.with_rule(stat, ModRule::ExpMul { base, per_level })
+    }
+
+    /// Get color from rarity
+    pub fn color(&self) -> Color {
+        self.rarity.color()
+    }
+
+    /// Get calculated stats at given level as `Stats`
+    pub fn calculate_stats(&self, level: u32) -> Stats {
+        let mut stats = Stats::zero();
+        self.for_each_value(level, |stat, value| {
+            stats.set(stat, value);
+        });
+        stats
+    }
+
+    /// Get formatted stat changes for this item at a specific level
+    /// Only shows stats that this item actually modifies
+    /// Used for ui
+    pub fn format_stats_at_level(&self, level: u32) -> String {
+        let mut text = String::new();
+
+        self.for_each_value(level, |stat, value| {
+            if value.abs() > 0.001 {
+                let formatted = stat.format_value(value);
+                text.push_str(&format!("{}: {}\n", stat.display_name(), formatted));
+            }
+        });
+
+        text
+    }
+
+    /// Get formatted upgrade text showing what changes from current to next level
+    /// Only shows stats that this item actually modifies
+    pub fn format_upgrade(&self, current_level: u32, next_level: u32) -> String {
+        let mut text = String::new();
+
+        self.for_each_delta(current_level, next_level, |stat, delta| {
+            if delta.abs() > 0.001 {
+                let formatted = stat.format_delta(delta);
+                text.push_str(&format!("{}: {}\n", stat.display_name(), formatted));
+            }
+        });
+
+        text
+    }
+}
+
+#[derive(Resource, Default)]
+pub struct ItemRegistry {
+    defs: HashMap<String, ItemSpec>,
+}
+
+impl ItemRegistry {
+    pub fn insert(&mut self, id: impl Into<String>, def: ItemSpec) {
+        self.defs.insert(id.into(), def);
+    }
+
+    pub fn get(&self, id: &str) -> Option<&ItemSpec> {
+        self.defs.get(id)
+    }
+}
+
+pub(super) fn plugin(app: &mut App) {
+    app.init_resource::<ItemRegistry>();
+
+    app.add_systems(Startup, register_builtin_items);
+}
+
+fn register_builtin_items(mut reg: ResMut<ItemRegistry>) {
+    // Passive items
+    reg.insert(
+        "tome_crit",
+        ItemSpec::new("Crit Tome", ItemCategory::Passive)
+            .with_rarity(ItemRarity::Uncommon)
+            .linear_add(StatId::CritChance, 0.0, 0.02),
+    );
+
+    reg.insert(
+        "tome_attack_speed",
+        ItemSpec::new("Attack Speed Tome", ItemCategory::Passive)
+            .with_rarity(ItemRarity::Rare)
+            .exp_mul(StatId::AttackSpeed, 1.0, 1.05),
+    );
+
+    reg.insert(
+        "health",
+        ItemSpec::new("Health", ItemCategory::Passive)
+            .with_rarity(ItemRarity::Common)
+            .linear_add(StatId::Attack, 0.0, 10.0),
+    );
+
+    reg.insert(
+        "wings",
+        ItemSpec::new("Wings", ItemCategory::Passive)
+            .with_rarity(ItemRarity::Common)
+            .exp_mul(StatId::MoveSpeed, 1.0, 1.1),
+    );
+}

--- a/src/gameplay/items/mod.rs
+++ b/src/gameplay/items/mod.rs
@@ -1,0 +1,10 @@
+use bevy::prelude::*;
+
+pub(crate) mod inventory;
+pub(crate) mod items;
+pub(crate) mod loader;
+pub(crate) mod stats;
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_plugins((stats::plugin, items::plugin, loader::plugin));
+}

--- a/src/gameplay/items/stats.rs
+++ b/src/gameplay/items/stats.rs
@@ -1,0 +1,351 @@
+use bevy::prelude::*;
+use std::ops::{Add, AddAssign, Mul, MulAssign};
+
+use crate::gameplay::player::{InInventoryOf, Inventory};
+
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(usize)]
+pub enum StatId {
+    // Damage stats
+    Attack,
+    CritChance,
+    CritDamage,
+    AttackSpeed,
+
+    // Movement & survivability
+    MoveSpeed,
+    MaxHealth,
+    Armor,
+    Recovery,
+
+    // Weapon modifiers
+    ProjectileCount,
+    Duration,
+    Area,
+    Cooldown,
+
+    // Utility
+    PickupRange,
+    // Luck,
+    // Greed,
+}
+
+impl StatId {
+    pub const COUNT: usize = 16;
+
+    /// Get the display name for this stat
+    pub fn display_name(self) -> &'static str {
+        match self {
+            StatId::Attack => "Attack",
+            StatId::CritChance => "Crit Chance",
+            StatId::CritDamage => "Crit Damage",
+            StatId::AttackSpeed => "Attack Speed",
+            StatId::MoveSpeed => "Move Speed",
+            StatId::MaxHealth => "Max Health",
+            StatId::Armor => "Armor",
+            StatId::Recovery => "Recovery",
+            StatId::ProjectileCount => "Projectile Count",
+            StatId::Duration => "Duration",
+            StatId::Area => "Area",
+            StatId::Cooldown => "Cooldown",
+            StatId::PickupRange => "Pickup Range",
+        }
+    }
+
+    /// Format a stat value for display
+    pub fn format_value(self, value: f32) -> String {
+        match self {
+            StatId::CritChance => format!("{:.1}%", value * 100.0),
+            StatId::CritDamage => format!("{:.0}%", (value - 1.0) * 100.0),
+            StatId::Armor => format!("{:.1}%", value * 100.0),
+            StatId::AttackSpeed
+            | StatId::MoveSpeed
+            | StatId::Duration
+            | StatId::Area
+            | StatId::Cooldown => {
+                format!("{:.0}%", (value - 1.0) * 100.0)
+            }
+            _ => format!("{:.1}", value),
+        }
+    }
+
+    /// Format a stat delta/change for display (e.g., for level-up screen)
+    pub fn format_delta(self, delta: f32) -> String {
+        match self {
+            StatId::CritChance => {
+                let percent = delta * 100.0;
+                if percent >= 0.0 {
+                    format!("+{:.1}%", percent)
+                } else {
+                    format!("{:.1}%", percent)
+                }
+            }
+            StatId::CritDamage => {
+                let percent = delta * 100.0;
+                if percent >= 0.0 {
+                    format!("+{:.0}%", percent)
+                } else {
+                    format!("{:.0}%", percent)
+                }
+            }
+            StatId::Armor => {
+                let percent = delta * 100.0;
+                if percent >= 0.0 {
+                    format!("+{:.1}%", percent)
+                } else {
+                    format!("{:.1}%", percent)
+                }
+            }
+            StatId::AttackSpeed
+            | StatId::MoveSpeed
+            | StatId::Duration
+            | StatId::Area
+            | StatId::Cooldown => {
+                let percent = delta * 100.0;
+                if percent >= 0.0 {
+                    format!("+{:.0}%", percent)
+                } else {
+                    format!("{:.0}%", percent)
+                }
+            }
+            _ => {
+                if delta >= 0.0 {
+                    format!("+{:.1}", delta)
+                } else {
+                    format!("{:.1}", delta)
+                }
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct Stats {
+    values: [f32; StatId::COUNT],
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl Stats {
+    #[inline]
+    pub fn zero() -> Self {
+        Self {
+            values: [0.0; StatId::COUNT],
+        }
+    }
+
+    /// used for multiplication
+    #[inline]
+    pub fn one() -> Self {
+        Self {
+            values: [1.0; StatId::COUNT],
+        }
+    }
+
+    #[inline]
+    pub fn get(&self, id: StatId) -> f32 {
+        self.values[id as usize]
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self, id: StatId) -> &mut f32 {
+        &mut self.values[id as usize]
+    }
+
+    #[inline]
+    pub fn set(&mut self, id: StatId, value: f32) {
+        self.values[id as usize] = value;
+    }
+
+    #[inline]
+    pub fn add_stat(&mut self, id: StatId, amount: f32) {
+        self.values[id as usize] += amount;
+    }
+
+    #[inline]
+    pub fn clamp_rules(mut self) -> Self {
+        *self.get_mut(StatId::CritChance) = self.get(StatId::CritChance).clamp(0.0, 1.0);
+        *self.get_mut(StatId::AttackSpeed) = self.get(StatId::AttackSpeed).max(0.05);
+        *self.get_mut(StatId::MoveSpeed) = self.get(StatId::MoveSpeed).max(0.1);
+        *self.get_mut(StatId::MaxHealth) = self.get(StatId::MaxHealth).max(1.0);
+        *self.get_mut(StatId::Armor) = self.get(StatId::Armor).clamp(0.0, 0.99);
+        *self.get_mut(StatId::Cooldown) = self.get(StatId::Cooldown).max(0.1);
+        self
+    }
+
+    /// Format a stat value for display
+    #[inline]
+    pub fn format(self, stat_id: StatId) -> String {
+        stat_id.format_value(self.get(stat_id))
+    }
+}
+
+impl Add for Stats {
+    type Output = Self;
+    #[inline]
+    fn add(self, rhs: Self) -> Self::Output {
+        let mut result = Self::zero();
+        for i in 0..StatId::COUNT {
+            result.values[i] = self.values[i] + rhs.values[i];
+        }
+        result
+    }
+}
+
+impl AddAssign for Stats {
+    #[inline]
+    fn add_assign(&mut self, rhs: Self) {
+        for i in 0..StatId::COUNT {
+            self.values[i] += rhs.values[i];
+        }
+    }
+}
+
+impl Mul for Stats {
+    type Output = Self;
+    #[inline]
+    fn mul(self, rhs: Self) -> Self::Output {
+        let mut result = Self::zero();
+        for i in 0..StatId::COUNT {
+            result.values[i] = self.values[i] * rhs.values[i];
+        }
+        result
+    }
+}
+
+impl MulAssign for Stats {
+    #[inline]
+    fn mul_assign(&mut self, rhs: Self) {
+        for i in 0..StatId::COUNT {
+            self.values[i] *= rhs.values[i];
+        }
+    }
+}
+
+#[derive(Component, Debug, Clone, Copy)]
+pub struct BaseStats(pub Stats);
+
+impl Default for BaseStats {
+    fn default() -> Self {
+        let mut stats = Stats::zero();
+
+        // Set multiplier-based stats to 1.0 (100% baseline)
+        stats.set(StatId::CritDamage, 1.5); // 150% crit damage baseline
+        stats.set(StatId::AttackSpeed, 1.0);
+        stats.set(StatId::MoveSpeed, 1.0);
+        stats.set(StatId::Duration, 1.0);
+        stats.set(StatId::Area, 1.0);
+        stats.set(StatId::Cooldown, 1.0);
+
+        // Set additive stats with reasonable defaults
+        stats.set(StatId::Attack, 10.0);
+        stats.set(StatId::MaxHealth, 100.0);
+        stats.set(StatId::PickupRange, 50.0);
+        stats.set(StatId::ProjectileCount, 1.0);
+
+        Self(stats)
+    }
+}
+
+#[derive(Component, Default, Debug, Clone, Copy)]
+pub struct UpgradeStats(pub Stats);
+
+#[derive(Component, Default, Debug, Clone, Copy)]
+pub struct DerivedStats(pub Stats);
+
+#[derive(Component, Debug, Clone, Copy)]
+pub struct ItemModifiers {
+    /// Flat additions (e.g. +10 attack)
+    pub add: Stats,
+    /// Multipliers (1.0 = no change). e.g. 1.10 for +10%
+    pub mul: Stats,
+}
+
+impl Default for ItemModifiers {
+    fn default() -> Self {
+        Self {
+            add: Stats::zero(),
+            mul: Stats::one(),
+        }
+    }
+}
+
+#[derive(EntityEvent)]
+pub struct AddUpgrade {
+    pub entity: Entity,
+    pub stat: StatId,
+    pub amount: f32,
+}
+
+#[derive(EntityEvent)]
+pub struct RecalculateStats {
+    pub entity: Entity,
+}
+
+pub(super) fn plugin(app: &mut App) {
+    app.add_observer(on_add_upgrade);
+    app.add_observer(on_item_modifiers_insert);
+    app.add_observer(on_item_modifiers_replace);
+    app.add_observer(on_recalculate_stats);
+}
+
+fn on_add_upgrade(ev: On<AddUpgrade>, mut commands: Commands, mut q: Query<&mut UpgradeStats>) {
+    if let Ok(mut upgrades) = q.get_mut(ev.entity) {
+        upgrades.0.add_stat(ev.stat, ev.amount);
+        commands.trigger(RecalculateStats { entity: ev.entity });
+    }
+}
+
+fn on_item_modifiers_insert(
+    ev: On<Insert, ItemModifiers>,
+    mut commands: Commands,
+    q_equipped_to: Query<&InInventoryOf>,
+) {
+    if let Ok(equipped_to) = q_equipped_to.get(ev.entity) {
+        commands.trigger(RecalculateStats {
+            entity: equipped_to.0,
+        });
+    }
+}
+
+fn on_item_modifiers_replace(
+    ev: On<Replace, ItemModifiers>,
+    mut commands: Commands,
+    q_equipped_to: Query<&InInventoryOf>,
+) {
+    if let Ok(equipped_to) = q_equipped_to.get(ev.entity) {
+        commands.trigger(RecalculateStats {
+            entity: equipped_to.0,
+        });
+    }
+}
+
+fn on_recalculate_stats(
+    ev: On<RecalculateStats>,
+    mut q_owner: Query<(&BaseStats, &UpgradeStats, &mut DerivedStats)>,
+    inventory: Query<&Inventory>,
+    q_mods: Query<&ItemModifiers>,
+) {
+    let Ok((base, upgrades, mut derived)) = q_owner.get_mut(ev.entity) else {
+        return;
+    };
+
+    // add starts from base + upgrades
+    let mut add = base.0 + upgrades.0;
+
+    // mul starts from 1.0
+    let mut mul = Stats::one();
+
+    for inventory_slot in inventory.iter_descendants(ev.entity) {
+        if let Ok(mods) = q_mods.get(inventory_slot) {
+            add += mods.add;
+            mul *= mods.mul;
+        }
+    }
+
+    derived.0 = (add * mul).clamp_rules();
+}

--- a/src/gameplay/items/stats.rs
+++ b/src/gameplay/items/stats.rs
@@ -234,7 +234,8 @@ impl Default for BaseStats {
         let mut stats = Stats::zero();
 
         // Set multiplier-based stats to 1.0 (100% baseline)
-        stats.set(StatId::CritDamage, 1.5); // 150% crit damage baseline
+        stats.set(StatId::CritChance, 0.5);
+        stats.set(StatId::CritDamage, 1.5);
         stats.set(StatId::AttackSpeed, 1.0);
         stats.set(StatId::MoveSpeed, 1.0);
         stats.set(StatId::Duration, 1.0);
@@ -254,8 +255,15 @@ impl Default for BaseStats {
 #[derive(Component, Default, Debug, Clone, Copy)]
 pub struct UpgradeStats(pub Stats);
 
-#[derive(Component, Default, Debug, Clone, Copy)]
+#[derive(Component, Debug, Clone, Copy)]
 pub struct DerivedStats(pub Stats);
+
+impl Default for DerivedStats {
+    fn default() -> Self {
+        // Start with BaseStats defaults so we always have valid values
+        Self(BaseStats::default().0)
+    }
+}
 
 #[derive(Component, Debug, Clone, Copy)]
 pub struct ItemModifiers {

--- a/src/gameplay/mod.rs
+++ b/src/gameplay/mod.rs
@@ -5,6 +5,7 @@ pub(crate) mod character_controller;
 pub(crate) mod damage_numbers;
 pub(crate) mod enemy;
 pub(crate) mod healthbar;
+pub(crate) mod items;
 pub(crate) mod level;
 pub(crate) mod overlays;
 pub(crate) mod player;
@@ -26,6 +27,7 @@ pub(crate) fn plugin(app: &mut App) {
         abilities::plugin,
         damage_numbers::plugin,
         enemy::plugin,
+        items::plugin,
         healthbar::plugin,
         level::plugin,
         overlays::plugin,

--- a/src/gameplay/overlays/experience.rs
+++ b/src/gameplay/overlays/experience.rs
@@ -59,7 +59,7 @@ fn spawn_xp_gem(
     commands.spawn((
         Name::new("XpGem"),
         Sprite {
-            image: asset_server.load("xp_gem.png"),
+            image: asset_server.load("xp_green.png"),
             ..default()
         },
         Transform::from_xyz(enemy_pos.x, enemy_pos.y, 10.),

--- a/src/gameplay/overlays/experience.rs
+++ b/src/gameplay/overlays/experience.rs
@@ -12,7 +12,7 @@ use crate::{
     audio::SfxPool,
     gameplay::{
         Speed,
-        enemy::EnemyDeathEvent,
+        enemy::damage::EnemyDeathEvent,
         overlays::Overlay,
         player::{Level, Player, XP, XpCollectionRange},
     },

--- a/src/gameplay/overlays/hud.rs
+++ b/src/gameplay/overlays/hud.rs
@@ -89,7 +89,7 @@ fn spawn_hud(
                 .spawn((
                     Name::new("LevelUp"),
                     Node {
-                        width: Val::Px(352.),
+                        width: Val::Px(416.),
                         height: Val::Px(96.),
                         display: Display::Flex,
                         position_type: PositionType::Relative,
@@ -118,7 +118,7 @@ fn spawn_hud(
                                 display: Display::Grid,
                                 width: Val::Percent(100.0),
                                 height: Val::Percent(100.0),
-                                grid_template_columns: RepeatedGridTrack::flex(11, 1.0),
+                                grid_template_columns: RepeatedGridTrack::flex(13, 1.0),
                                 grid_template_rows: RepeatedGridTrack::flex(3, 1.0),
                                 position_type: PositionType::Absolute,
                                 ..default()

--- a/src/gameplay/overlays/level_up.rs
+++ b/src/gameplay/overlays/level_up.rs
@@ -1,4 +1,3 @@
-//! The level up menu.
 use bevy::{color::palettes::basic, prelude::*, text::FontSmoothing};
 use bevy_rand::{global::GlobalRng, prelude::WyRand};
 use rand::Rng;

--- a/src/gameplay/overlays/mod.rs
+++ b/src/gameplay/overlays/mod.rs
@@ -7,9 +7,7 @@ use bevy::prelude::*;
 pub(super) fn plugin(app: &mut App) {
     app.init_state::<Overlay>();
 
-    app.add_plugins(experience::plugin);
-    app.add_plugins(level_up::plugin);
-    app.add_plugins(hud::plugin);
+    app.add_plugins((experience::plugin, level_up::plugin, hud::plugin));
 }
 
 #[derive(States, Copy, Clone, Eq, PartialEq, Hash, Debug, Default)]

--- a/src/gameplay/player/mod.rs
+++ b/src/gameplay/player/mod.rs
@@ -11,7 +11,9 @@ use bevy_seedling::sample::AudioSample;
 use crate::gameplay::abilities;
 use crate::gameplay::character_controller::CharacterController;
 use crate::gameplay::items::items::{ItemId, ItemLevel};
-use crate::gameplay::items::stats::{BaseStats, DerivedStats, ItemModifiers, UpgradeStats};
+use crate::gameplay::items::stats::{
+    BaseStats, DerivedStats, ItemModifiers, RecalculateStats, StatId, UpgradeStats,
+};
 use crate::gameplay::player::characters::Characters;
 use crate::gameplay::{
     Health,
@@ -45,6 +47,7 @@ pub(super) fn plugin(app: &mut App) {
 
     app.add_observer(setup_player);
     app.add_observer(patch_player_spawn_pos);
+    app.add_observer(update_player_stats_on_change);
 }
 
 #[derive(Event)]
@@ -117,6 +120,9 @@ pub(crate) struct PlayerSpawnPoint;
 
 #[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Default, Reflect)]
 #[require(
+    BaseStats,
+    UpgradeStats,
+    DerivedStats,
     Health(100.),
     XpCollectionRange(150.0),
     XP(0.),
@@ -166,9 +172,6 @@ fn setup_player(
                 index: 0,
             },
         ),
-        BaseStats::default(),
-        UpgradeStats::default(),
-        DerivedStats::default(),
         CollisionLayers::new(
             GameLayer::Player,
             [
@@ -218,6 +221,9 @@ fn setup_player(
         ItemModifiers::default(),
     ));
 
+    commands.trigger(RecalculateStats {
+        entity: player_add.entity,
+    });
     commands.trigger(PlayerSetupComplete);
 }
 
@@ -230,6 +236,26 @@ fn patch_player_spawn_pos(
     for mut player_pos in player_pos.iter_mut() {
         *player_pos = spawn_transform;
     }
+}
+
+fn update_player_stats_on_change(
+    trigger: On<RecalculateStats>,
+    mut player_q: Query<(&mut CharacterController, &mut Health), With<Player>>,
+    stats_q: Query<&DerivedStats>,
+) {
+    let Ok(stats) = stats_q.get(trigger.entity) else {
+        return;
+    };
+
+    let Ok((mut controller, mut health)) = player_q.get_mut(trigger.entity) else {
+        return;
+    };
+
+    let move_speed = stats.0.get(StatId::MoveSpeed);
+    let max_health = stats.0.get(StatId::MaxHealth);
+
+    controller.speed = move_speed * 100.0;
+    health.0 = health.0.min(max_health);
 }
 
 fn player_input_actions() -> impl Bundle {

--- a/src/gameplay/player/mod.rs
+++ b/src/gameplay/player/mod.rs
@@ -10,6 +10,8 @@ use bevy_seedling::sample::AudioSample;
 
 use crate::gameplay::abilities;
 use crate::gameplay::character_controller::CharacterController;
+use crate::gameplay::items::items::{ItemId, ItemLevel};
+use crate::gameplay::items::stats::{BaseStats, DerivedStats, ItemModifiers, UpgradeStats};
 use crate::gameplay::player::characters::Characters;
 use crate::gameplay::{
     Health,
@@ -81,7 +83,7 @@ pub(crate) struct Level(pub f32);
 #[derive(Component)]
 #[relationship_target(relationship = InInventoryOf)]
 #[derive(Reflect)]
-pub(crate) struct Inventory(Vec<Entity>);
+pub(crate) struct Inventory(Vec<Entity>); //EquippedBy
 
 #[derive(Component)]
 #[relationship(relationship_target = Inventory)]
@@ -164,6 +166,9 @@ fn setup_player(
                 index: 0,
             },
         ),
+        BaseStats::default(),
+        UpgradeStats::default(),
+        DerivedStats::default(),
         CollisionLayers::new(
             GameLayer::Player,
             [
@@ -206,6 +211,12 @@ fn setup_player(
     commands.spawn((abilities::QAbility, abilities::heal::Heal));
     commands.spawn((abilities::EAbility, abilities::dash::Dash));
     commands.spawn((abilities::RAbility, abilities::shield::Shield));
+    commands.spawn((
+        ItemId("tome_crit".to_string()),
+        ItemLevel(1),
+        InInventoryOf(player_add.entity),
+        ItemModifiers::default(),
+    ));
 
     commands.trigger(PlayerSetupComplete);
 }

--- a/src/gameplay/weapons/behaviours/chain/attack.rs
+++ b/src/gameplay/weapons/behaviours/chain/attack.rs
@@ -13,7 +13,7 @@ use crate::{
             },
             components::{BaseDamage, ProjectileCount, WeaponRange},
             spec::components::HitSpec,
-            systems::{cooldown::WeaponDuration, hit::WeaponHitEvent},
+            systems::{cooldown::WeaponDurationTimer, hit::WeaponHitEvent},
         },
     },
 };
@@ -87,7 +87,7 @@ pub fn on_chain_attack(
                 rotation: Quat::from_rotation_z(angle),
                 scale: Vec3::new(length / 16.0, 1.0, 1.0),
             },
-            WeaponDuration(Timer::from_seconds(bolt_lifetime.0, TimerMode::Once)),
+            WeaponDurationTimer(Timer::from_seconds(bolt_lifetime.0, TimerMode::Once)),
         ));
 
         projectile_visuals.0.apply_ec(&mut bolt);

--- a/src/gameplay/weapons/behaviours/homing/attack.rs
+++ b/src/gameplay/weapons/behaviours/homing/attack.rs
@@ -12,7 +12,7 @@ use crate::{
                 },
             },
             components::{CastWeapon, ProjectileCount, ProjectileDirection, WeaponLifetime},
-            systems::cooldown::WeaponDuration,
+            systems::cooldown::WeaponDurationTimer,
         },
     },
 };
@@ -74,7 +74,7 @@ pub fn on_homing_attack(
                 max_hits: max_hits.0 as usize,
             },
             movement_config.clone(),
-            WeaponDuration(Timer::from_seconds(lifetime.0, TimerMode::Once)),
+            WeaponDurationTimer(Timer::from_seconds(lifetime.0, TimerMode::Once)),
         ));
 
         projectile_visuals.0.apply_ec(&mut proj);

--- a/src/gameplay/weapons/behaviours/melee/attack.rs
+++ b/src/gameplay/weapons/behaviours/melee/attack.rs
@@ -9,7 +9,7 @@ use crate::{
                 melee::{AttackCone, MeleeAttack, MeleeAttackZone},
             },
             components::CastWeapon,
-            systems::cooldown::WeaponDuration,
+            systems::cooldown::WeaponDurationTimer,
         },
     },
 };
@@ -60,7 +60,7 @@ pub fn on_melee_attack(
             CollisionLayers::new(GameLayer::Player, [GameLayer::Enemy, GameLayer::Default]),
             DebugRender::default().with_collider_color(Color::srgb(0.0, 1.0, 0.0)),
             Transform::from_xyz(player_pos.translation.x, player_pos.translation.y, 10.0),
-            WeaponDuration(Timer::from_seconds(duration_secs, TimerMode::Once)),
+            WeaponDurationTimer(Timer::from_seconds(duration_secs, TimerMode::Once)),
             Visibility::default(),
         ))
         .id();

--- a/src/gameplay/weapons/behaviours/orbiters/attack.rs
+++ b/src/gameplay/weapons/behaviours/orbiters/attack.rs
@@ -10,7 +10,7 @@ use crate::{
                 },
             },
             components::{CastWeapon, PlayerProjectile, ProjectileCount, WeaponLifetime},
-            systems::cooldown::WeaponDuration,
+            systems::cooldown::WeaponDurationTimer,
         },
     },
 };
@@ -52,7 +52,7 @@ pub fn on_orbiters_attack(
             OrbitPhase(phase),
             OrbitRadius(radius.0),
             OrbitAngularSpeed(ang_speed.0),
-            WeaponDuration(Timer::from_seconds(lifetime.0, TimerMode::Once)),
+            WeaponDurationTimer(Timer::from_seconds(lifetime.0, TimerMode::Once)),
             Transform::from_xyz(world_pos.x, world_pos.y, 10.0),
             // physics
             Collider::rectangle(16., 16.),

--- a/src/gameplay/weapons/behaviours/zone/attack.rs
+++ b/src/gameplay/weapons/behaviours/zone/attack.rs
@@ -9,7 +9,7 @@ use crate::{
                 zone::{ZoneAttack, ZoneShape, ZoneTarget},
             },
             components::{CastWeapon, WeaponLifetime},
-            systems::cooldown::WeaponDuration,
+            systems::cooldown::WeaponDurationTimer,
         },
     },
 };
@@ -65,7 +65,7 @@ pub fn on_zone_attack(
             scale: scale.extend(1.0),
             ..default()
         },
-        WeaponDuration(Timer::from_seconds(lifetime.0, TimerMode::Once)),
+        WeaponDurationTimer(Timer::from_seconds(lifetime.0, TimerMode::Once)),
     ));
 
     visuals.0.apply_ec(&mut proj);

--- a/src/gameplay/weapons/components.rs
+++ b/src/gameplay/weapons/components.rs
@@ -3,7 +3,7 @@ use bevy::prelude::*;
 
 use crate::{
     GameLayer,
-    gameplay::{damage_numbers::DamageType, weapons::systems::cooldown::WeaponDuration},
+    gameplay::{damage_numbers::DamageType, weapons::systems::cooldown::WeaponDurationTimer},
 };
 
 #[derive(Component)]
@@ -23,7 +23,7 @@ pub struct Weapon;
         ],
     ),
     // TODO: This is a placeholder to remove projectiles after some time.
-    WeaponDuration(Timer::from_seconds(5.0, TimerMode::Once)),
+    WeaponDurationTimer(Timer::from_seconds(5.0, TimerMode::Once)),
 )]
 pub(crate) struct PlayerProjectile;
 

--- a/src/gameplay/weapons/mod.rs
+++ b/src/gameplay/weapons/mod.rs
@@ -6,7 +6,7 @@ use crate::gameplay::{
         behaviours::{WeaponImpactVisuals, WeaponProjectileVisuals},
         components::{BaseDamage, CollisionDamage, DeathOnCollision, TickDuration, Weapon},
         spec::components::WeaponSpec,
-        systems::cooldown::WeaponCooldown,
+        systems::cooldown::{WeaponBaseCooldown, WeaponCooldownTimer},
     },
 };
 
@@ -37,7 +37,8 @@ impl Command for AddWeapon {
             self.0.kind,
             InInventoryOf(player),
             BaseDamage(self.0.base_damage),
-            WeaponCooldown(Timer::from_seconds(self.0.cooldown, TimerMode::Repeating)),
+            WeaponBaseCooldown(self.0.cooldown),
+            WeaponCooldownTimer(Timer::from_seconds(self.0.cooldown, TimerMode::Repeating)),
             WeaponProjectileVisuals(self.0.visuals),
         ));
 

--- a/src/gameplay/weapons/systems/cooldown.rs
+++ b/src/gameplay/weapons/systems/cooldown.rs
@@ -2,15 +2,26 @@ use bevy::prelude::*;
 
 use crate::{
     PausableSystems,
-    gameplay::weapons::{components::Weapon, systems::attack::WeaponAttack},
+    gameplay::{
+        items::stats::{DerivedStats, RecalculateStats, StatId},
+        player::InInventoryOf,
+        weapons::{components::Weapon, systems::attack::WeaponAttack},
+    },
     screens::Screen,
 };
 
 #[derive(Component, Default, Reflect)]
-pub struct WeaponCooldown(pub Timer);
+pub struct WeaponCooldownTimer(pub Timer);
 
 #[derive(Component, Reflect)]
-pub struct WeaponDuration(pub Timer);
+pub struct WeaponDurationTimer(pub Timer);
+
+#[derive(Component, Reflect)]
+pub struct WeaponBaseCooldown(pub f32);
+
+// TODO: ADD IF WE HAVE A STAT FOR IT
+// #[derive(Component, Reflect)]
+// pub struct BaseDuration(pub f32);
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(
@@ -19,13 +30,14 @@ pub(super) fn plugin(app: &mut App) {
             .run_if(in_state(Screen::Gameplay))
             .in_set(PausableSystems),
     );
+    app.add_observer(update_weapon_cooldowns_on_stat_change);
 }
 
 fn handle_timers(
     mut commands: Commands,
     time: Res<Time>,
-    mut weapon_q: Query<(Entity, &mut WeaponCooldown), With<Weapon>>,
-    mut durations: Query<&mut WeaponDuration>,
+    mut weapon_q: Query<(Entity, &mut WeaponCooldownTimer), With<Weapon>>,
+    mut durations: Query<&mut WeaponDurationTimer>,
 ) {
     for (entity, mut cooldown) in &mut weapon_q {
         if cooldown.0.just_finished() {
@@ -39,10 +51,31 @@ fn handle_timers(
     }
 }
 
-pub fn tick_despawn_after(q: Query<(Entity, &mut WeaponDuration)>, mut commands: Commands) {
+pub fn tick_despawn_after(q: Query<(Entity, &mut WeaponDurationTimer)>, mut commands: Commands) {
     for (e, t) in q {
         if t.0.is_finished() {
             commands.entity(e).despawn();
+        }
+    }
+}
+
+fn update_weapon_cooldowns_on_stat_change(
+    trigger: On<RecalculateStats>,
+    player_stats: Query<&DerivedStats>,
+    weapon_q: Query<(&InInventoryOf, &WeaponBaseCooldown, &mut WeaponCooldownTimer), With<Weapon>>,
+) {
+    let Ok(stats) = player_stats.get(trigger.entity) else {
+        return;
+    };
+
+    let attack_speed = stats.0.get(StatId::AttackSpeed);
+
+    for (inventory_of, base_cooldown, mut cooldown) in weapon_q {
+        if inventory_of.0 == trigger.entity {
+            let new_duration = base_cooldown.0 / attack_speed;
+            cooldown
+                .0
+                .set_duration(std::time::Duration::from_secs_f32(new_duration));
         }
     }
 }

--- a/src/gameplay/weapons/systems/hit.rs
+++ b/src/gameplay/weapons/systems/hit.rs
@@ -1,7 +1,7 @@
 use crate::audio::SfxPool;
 use crate::gameplay::{
     damage_numbers::DamageType,
-    enemy::{Enemy, EnemyDamageEvent, Root},
+    enemy::{Enemy, Root, damage::EnemyDamageEvent},
     simple_animation::AnimationPlayback,
     weapons::{
         behaviours::{WeaponImpactSfx, WeaponImpactVisuals},

--- a/src/menus/character_selection.rs
+++ b/src/menus/character_selection.rs
@@ -10,7 +10,7 @@ use crate::theme::palette::{
     BUTTON_BACKGROUND, BUTTON_HOVERED_BACKGROUND, BUTTON_PRESSED_BACKGROUND,
 };
 use crate::theme::prelude::InteractionPalette;
-use crate::theme::widget;
+use crate::theme::widget::{self, ButtonConfig};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Menu::CharacterSelection), spawn_character_screen);
@@ -49,7 +49,7 @@ fn spawn_character_screen(
                     },
                 )),
                 Spawn(spawn_character_grid(asset_server, texture_atlases)),
-                Spawn(widget::button("Back", back)),
+                Spawn(widget::button("Back", back, ButtonConfig::default())),
             )),
         ))),
     ));

--- a/src/menus/main.rs
+++ b/src/menus/main.rs
@@ -6,7 +6,10 @@ use crate::{
     AssetStates,
     menus::Menu,
     screens::Screen,
-    theme::{palette::SCREEN_BACKGROUND, widget},
+    theme::{
+        palette::SCREEN_BACKGROUND,
+        widget::{self, ButtonConfig},
+    },
 };
 
 pub(super) fn plugin(app: &mut App) {
@@ -30,9 +33,9 @@ fn spawn_main_menu(mut commands: Commands, asset_server: Res<AssetServer>) {
                 },
                 ImageNode::new(asset_server.load("splash_bs.png",)),
             ),
-            widget::button("Play", start),
-            widget::button("Settings", open_settings_menu),
-            widget::button("Exit", exit_app),
+            widget::button("Play", start, ButtonConfig::default()),
+            widget::button("Settings", open_settings_menu, ButtonConfig::default()),
+            widget::button("Exit", exit_app, ButtonConfig::default()),
         ],
     ));
 }

--- a/src/menus/pause.rs
+++ b/src/menus/pause.rs
@@ -1,8 +1,15 @@
 //! The pause menu.
 
-use bevy::{input::common_conditions::input_just_pressed, prelude::*};
+use bevy::{
+    input::common_conditions::input_just_pressed, prelude::*, text::FontSmoothing, ui::Val::*,
+};
 
-use crate::{menus::Menu, screens::Screen, theme::widget};
+use crate::{
+    gameplay::items::stats::{DerivedStats, StatId},
+    menus::Menu,
+    screens::Screen,
+    theme::widget::{self, ButtonConfig},
+};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Menu::Pause), spawn_pause_menu);
@@ -12,18 +19,168 @@ pub(super) fn plugin(app: &mut App) {
     );
 }
 
-fn spawn_pause_menu(mut commands: Commands) {
+fn spawn_pause_menu(
+    mut commands: Commands,
+    asset_server: Res<AssetServer>,
+    stats_q: Single<&DerivedStats>,
+) {
+    let font: Handle<Font> = asset_server.load("ui/compass.ttf");
+    let stats = stats_q.into_inner();
+
     commands.spawn((
         widget::ui_root("Pause Menu"),
         GlobalZIndex(2),
         DespawnOnExit(Menu::Pause),
         children![
-            widget::header("Game paused"),
-            widget::button("Continue", close_menu),
-            widget::button("Settings", open_settings_menu),
-            widget::button("Quit to title", quit_to_title),
+            widget::header("Game Paused"),
+            stats_display(&font, stats),
+            pause_actions()
         ],
     ));
+}
+
+fn pause_actions() -> impl Bundle {
+    (
+        Name::new("Pause Actions"),
+        Node {
+            column_gap: px(20),
+            ..default()
+        },
+        children![
+            widget::button(
+                "Quit to title",
+                quit_to_title,
+                ButtonConfig {
+                    width: Px(200.0),
+                    height: Px(40.0),
+                    text_size: 18.0,
+                }
+            ),
+            widget::button(
+                "Settings",
+                open_settings_menu,
+                ButtonConfig {
+                    width: Px(200.0),
+                    height: Px(40.0),
+                    text_size: 18.0,
+                }
+            ),
+            widget::button(
+                "Continue",
+                close_menu,
+                ButtonConfig {
+                    width: Px(200.0),
+                    height: Px(40.0),
+                    text_size: 18.0,
+                }
+            ),
+        ],
+    )
+}
+
+fn stats_display(font: &Handle<Font>, stats_q: &DerivedStats) -> impl Bundle {
+    let stats = stats_q.0;
+
+    (
+        Node {
+            display: Display::Flex,
+            flex_direction: FlexDirection::Column,
+            row_gap: px(12),
+            padding: UiRect::all(px(8)),
+            ..default()
+        },
+        Children::spawn((
+            Spawn((
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    row_gap: px(2),
+                    ..default()
+                },
+                Children::spawn((
+                    Spawn(section_header("Combat Stats", font)),
+                    Spawn(stat_row(stats, StatId::Attack, font)),
+                    Spawn(stat_row(stats, StatId::CritChance, font)),
+                    Spawn(stat_row(stats, StatId::CritDamage, font)),
+                    Spawn(stat_row(stats, StatId::AttackSpeed, font)),
+                )),
+            )),
+            Spawn((
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    row_gap: px(2),
+                    ..default()
+                },
+                Children::spawn((
+                    Spawn(section_header("Movement & Survivability", font)),
+                    Spawn(stat_row(stats, StatId::MoveSpeed, font)),
+                    Spawn(stat_row(stats, StatId::MaxHealth, font)),
+                    Spawn(stat_row(stats, StatId::Armor, font)),
+                    Spawn(stat_row(stats, StatId::Recovery, font)),
+                )),
+            )),
+            Spawn((
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    row_gap: px(2),
+                    ..default()
+                },
+                Children::spawn((
+                    Spawn(section_header("Weapon Modifiers", font)),
+                    Spawn(stat_row(stats, StatId::ProjectileCount, font)),
+                    Spawn(stat_row(stats, StatId::Duration, font)),
+                    Spawn(stat_row(stats, StatId::Area, font)),
+                    Spawn(stat_row(stats, StatId::Cooldown, font)),
+                )),
+            )),
+            Spawn((
+                Node {
+                    display: Display::Flex,
+                    flex_direction: FlexDirection::Column,
+                    row_gap: px(2),
+                    ..default()
+                },
+                Children::spawn((
+                    Spawn(section_header("Utility", font)),
+                    Spawn(stat_row(stats, StatId::PickupRange, font)),
+                )),
+            )),
+        )),
+    )
+}
+
+fn section_header(title: &str, font: &Handle<Font>) -> impl Bundle {
+    (
+        Text::new(title),
+        TextFont {
+            font: font.clone(),
+            font_size: 16.0,
+            font_smoothing: FontSmoothing::None,
+            ..default()
+        },
+        TextColor(Color::srgb(1.0, 0.8, 0.3)),
+    )
+}
+
+fn stat_row(
+    stats: crate::gameplay::items::stats::Stats,
+    stat_id: StatId,
+    font: &Handle<Font>,
+) -> impl Bundle {
+    let label = stat_id.display_name();
+    let formatted_value = stats.format(stat_id);
+
+    (
+        Text::new(format!("{label}: {formatted_value}")),
+        TextFont {
+            font: font.clone(),
+            font_size: 16.0,
+            font_smoothing: FontSmoothing::None,
+            ..default()
+        },
+    )
 }
 
 fn open_settings_menu(_: On<Pointer<Click>>, mut next_menu: ResMut<NextState<Menu>>) {

--- a/src/menus/settings.rs
+++ b/src/menus/settings.rs
@@ -5,7 +5,11 @@
 use bevy::{input::common_conditions::input_just_pressed, prelude::*};
 use bevy_seedling::prelude::*;
 
-use crate::{menus::Menu, screens::Screen, theme::prelude::*};
+use crate::{
+    menus::Menu,
+    screens::Screen,
+    theme::{prelude::*, widget::ButtonConfig},
+};
 
 pub(super) fn plugin(app: &mut App) {
     app.add_systems(OnEnter(Menu::Settings), spawn_settings_menu);
@@ -28,7 +32,7 @@ fn spawn_settings_menu(mut commands: Commands) {
         children![
             widget::header("Settings"),
             settings_grid(),
-            widget::button("Back", go_back_on_click),
+            widget::button("Back", go_back_on_click, ButtonConfig::default()),
         ],
     ));
 }

--- a/src/theme/widget.rs
+++ b/src/theme/widget.rs
@@ -58,8 +58,28 @@ fn label_base(text: impl Into<String>, font_size: f32) -> impl Bundle {
     )
 }
 
+pub(crate) struct ButtonConfig {
+    pub width: Val,
+    pub height: Val,
+    pub text_size: f32,
+}
+
+impl Default for ButtonConfig {
+    fn default() -> Self {
+        Self {
+            width: Px(380.0),
+            height: Px(80.0),
+            text_size: 40.0,
+        }
+    }
+}
+
 /// A large rounded button with text and an action defined as an [`Observer`].
-pub(crate) fn button<E, B, M, I>(text: impl Into<String>, action: I) -> impl Bundle
+pub(crate) fn button<E, B, M, I>(
+    text: impl Into<String>,
+    action: I,
+    config: ButtonConfig,
+) -> impl Bundle
 where
     E: EntityEvent,
     B: Bundle,
@@ -67,11 +87,12 @@ where
 {
     button_base(
         text,
+        config.text_size,
         action,
         (
             Node {
-                width: Px(380.0),
-                height: Px(80.0),
+                width: config.width,
+                height: config.height,
                 align_items: AlignItems::Center,
                 justify_content: JustifyContent::Center,
                 ..default()
@@ -90,6 +111,7 @@ where
 {
     button_base(
         text,
+        42.0,
         action,
         Node {
             width: Px(30.0),
@@ -104,6 +126,7 @@ where
 /// A simple button with text and an action defined as an [`Observer`]. The button's layout is provided by `button_bundle`.
 fn button_base<E, B, M, I>(
     text: impl Into<String>,
+    text_size: f32,
     action: I,
     button_bundle: impl Bundle,
 ) -> impl Bundle
@@ -117,7 +140,7 @@ where
     (
         Name::new("Button"),
         Node::default(),
-        Children::spawn(SpawnWith(|parent: &mut ChildSpawner| {
+        Children::spawn(SpawnWith(move |parent: &mut ChildSpawner| {
             parent
                 .spawn((
                     Name::new("Button Inner"),
@@ -131,7 +154,7 @@ where
                     children![(
                         Name::new("Button Text"),
                         Text(text),
-                        TextFont::from_font_size(40.0),
+                        TextFont::from_font_size(text_size),
                         TextColor(BUTTON_TEXT.into()),
                         // Don't bubble picking events from the text up to the button.
                         Pickable::IGNORE,


### PR DESCRIPTION
# Stats
3 types of Components. BaseStats set by char, Upgradestats (modified by items), DerivedStats(computed, used to calculate damage)

# Items
Item Modifiers setup. Can be used in #18 to load items from RON and increase stats

# UI
Pause Menu shows current stats